### PR TITLE
use  relative install-scripts path

### DIFF
--- a/dhpython/build/plugin_distutils.py
+++ b/dhpython/build/plugin_distutils.py
@@ -48,8 +48,9 @@ def create_pydistutils_cfg(func):
                          '[install]\n',
                          'force=1\n',
                          'install-layout=deb\n',
-                         'install-scripts=/usr/bin\n',
+                         'install-scripts=$base/bin\n',
                          'install-lib={}\n'.format(args['install_dir']),
+                         'prefix=/usr\n',
                          '[easy_install]\n',
                          'allow_hosts=None\n']
                 log.debug('pydistutils config file:\n%s', ''.join(lines))


### PR DESCRIPTION
I am not sure if this is the right location to propose changes since this is the first PR on this repo. Please guide me to the right place if it is not.

Let me describe the use case a bit to understand what I am trying to address with this patch. I am generating custom Debian packages using `dh-python` which are installed into a custom prefix, e.g. `/opt/mystuff`. Therefore the Debian rule file passes `--prefix /opt/mystuff`. Additionally some packages decide that they want to install their scripts and/or entry points into a different location (not `bin`). They do that in their `setup.cfg` file by specifying e.g. `[install] install-scripts=$base/lib/pkgname`. The usage of `$base` allows them to not hard code a specific prefix so it works wherever the user wants to install the package to.

In order to match the from-source behavior the Debian rule file needs to conditionally pass `--install-scripts` (beside passing `--prefix /opt/mystuff`):

* If a package doesn't specify a custom script location in its `setup.cfg` file the Debian rule needs to pass `--install-scripts /opy/mystuff/bin` (or `$base/bin`) to override the default coming from the `.pydistutils.cfg` file. (The reason is that the hard coded value in the `.pydistutils.cfg` file doesn't make sense when the user passes `--prefix`.)

* If a package does specify a custom script location the Debian rule file must **not** pass `--install-scripts`. (If it would pass `--install-scripts` that would override the package specific setting from the `setup.cfg` file which is not desired.)

In order to manage a larger scale of packages efficiently using generated Debian rule files makes sense (assuming that the necessary metadata is available somehow). The problem now is that in order to generate the "correct" Debian rule file for a package needs to parse and interpret the packages `setup.cfg` file. While that is a possible workaround at the moment I would like to avoid that extra step.

Finally getting to the proposed patch: the fact that the value of `install-scripts` contains a hard coded absolute path is the source of the problem when passing only `prefix` to the invocation. If the value for `install-scripts` would be relative to `$base` instead passing just `prefix` would work as expected (the same as from source, whether the package has a `setup.cfg` file or not). To maintain the same default behavior I also set `prefix=/usr`.

I certainly don't know much about `dh-python` and maybe my proposed patch has unwanted side effects. I am happy about any kind of feedback.