### PR TITLE
Use a more explicit name for pyremove in manual

### DIFF
--- a/dh_python2.rst
+++ b/dh_python2.rst
@@ -128,7 +128,7 @@ pyremove files
 ~~~~~~~~~~~~~~
 If you want to remove some public modules (i.e. files in .../dist-packages/
 directory) installed by build system (from all supported Python versions or
-only from a subset of these versions), add them to debian/pkg.pyremove file.
+only from a subset of these versions), add them to debian/{pkg-name}.pyremove file.
 
 Examples:
  * ``*.pth`` removes .pth files from .../dist-packages/

--- a/dh_python3.rst
+++ b/dh_python3.rst
@@ -114,7 +114,7 @@ pyremove files
 ~~~~~~~~~~~~~~
 If you want to remove some public modules (i.e. files in .../dist-packages/
 directory) installed by build system (from all supported Python versions or
-only from a subset of these versions), add them to debian/pkg.pyremove file.
+only from a subset of these versions), add them to debian/{pkg-name}.pyremove file.
 
 Examples:
  * ``*.pth`` removes .pth files from .../dist-packages/


### PR DESCRIPTION
Replace `pkg.pyremove` by `{pkg-name}.pyremove` in the "pyremove files"
section

Motivation: I had to read the source of dh_python to understand that
"pkg" was not a hardcoded name, but the name of the package

Hopefully this will avoid similar confusion for other developers not
familiar with packaging