### PR TITLE
Add PYBUILD_SNAKE to let python from venv and install to venv

### DIFF
--- a/dhpython/interpreter.py
+++ b/dhpython/interpreter.py
@@ -72,7 +72,7 @@ class Interpreter:
     :type impl: str
     :type options: tuple
     """
-    path = '/usr/bin/'
+    path = os.environ['PYBUILD_SNAKE'] if 'PYBUILD_SNAKE' in os.environ else '/usr/bin/'
     name = 'python'
     version = None
     debug = False


### PR DESCRIPTION
When the developer uses python venv he may want to specify python interpreter with the full path. 
The example of the debian/rules:
```
DH_ARGS=--with python3 --buildsystem=pybuild
PYBUILD_SNAKE=/opt/my_product_in_venv/
%:
    dh $@ $(DH_ARGS)

```    
This allow install all the code into virtual environment of other debian package. For example the xxx-lib.deb contains just venv and aaa.deb & bbb.deb has the modules of two separate utilities etc.